### PR TITLE
Update Kaggle dataset link in Chapter_02.ipynb

### DIFF
--- a/Chapter_02.ipynb
+++ b/Chapter_02.ipynb
@@ -23,7 +23,7 @@
     "For practicing biostatistical techniques, any dataset with numerical and categorical variables can be used. Here, you can use the **Diabetes dataset** for exploratory analysis.\n",
     "\n",
     "1. **Kaggle:**\n",
-    "   - [Diabetes Dataset - Kaggle](https://www.kaggle.com/datasets/mathchi/diabetes-data)\n",
+    "   - [Diabetes Dataset - Kaggle](https://www.kaggle.com/datasets/mathchi/diabetes-data-set)\n",
     "\n",
     "### Dataset Attributes\n",
     "\n",


### PR DESCRIPTION
The current link is broken:
https://www.kaggle.com/datasets/mathchi/diabetes-data

The proposed working link is:
https://www.kaggle.com/datasets/mathchi/diabetes-data-set